### PR TITLE
Replace \begin{} and \end{} with \[ and \]

### DIFF
--- a/_version.py
+++ b/_version.py
@@ -10,4 +10,4 @@ Copyright: (c) 2023-2027 Achyut Morang <achyut.morang@gmail.com>
 License: MIT License <https://opensource.org/license/mit/>
 """
 
-__version__ = "1.0"
+__version__ = "1.1"

--- a/main.py
+++ b/main.py
@@ -42,6 +42,10 @@ def replaceMathDelimiters(editor):
 
     # Preserve newline breaks in the modified text
     modified_text = modified_text.replace("\\n", "<br>")
+    
+    # Replace \begin and \end with \[ and \]
+    modified_text = re.sub(r'\\begin{(\w+)}|\\end{(\w+)}', lambda m: r'\[' if m.group().startswith(r'\begin') else r'\]', modified_text)
+
 
     # Execute JavaScript to replace the selected text with modified text
     replace_selected_text_script = f"""

--- a/main.py
+++ b/main.py
@@ -46,7 +46,6 @@ def replaceMathDelimiters(editor):
     # Replace \begin and \end with \[ and \]
     modified_text = re.sub(r'\\begin{(\w+)}|\\end{(\w+)}', lambda m: r'\[' if m.group().startswith(r'\begin') else r'\]', modified_text)
 
-
     # Execute JavaScript to replace the selected text with modified text
     replace_selected_text_script = f"""
     document.execCommand('insertHtml', false, '{modified_text}');


### PR DESCRIPTION
Supports "\begin{}" and "\end{}" and replaces them with "\\[" and "\\]"
Fixes #1